### PR TITLE
Tidy up instruction access in Program

### DIFF
--- a/lib/brainfuck/machine.rb
+++ b/lib/brainfuck/machine.rb
@@ -43,7 +43,7 @@ module Brainfuck
     end
 
     def fetch
-      program[instruction_pointer]
+      program.instruction(instruction_pointer)
     end
 
     def increment_instruction_pointer

--- a/lib/brainfuck/program.rb
+++ b/lib/brainfuck/program.rb
@@ -10,9 +10,9 @@ module Brainfuck
 
     attr_reader :source
 
-    def_delegators :instructions, :size, :[]
+    def_delegators :instructions, :size
 
-    check_bounds :[], proc: ->(i) { (0..size).include? i }
+    check_bounds :instruction, proc: ->(i) { (0..size).include? i }
 
     def self.from_file(filename)
       source = File.read(filename)
@@ -29,9 +29,8 @@ module Brainfuck
       @source = source.to_s
     end
 
-    # we want some better bounds checking here
     def instruction(index)
-      parsed_source.fetch(index)
+      instructions.fetch(index)
     end
 
     def valid?

--- a/spec/machine_spec.rb
+++ b/spec/machine_spec.rb
@@ -15,7 +15,7 @@ describe Brainfuck::Machine do
   describe "#run" do
     it "runs a valid program" do
       allow(program).to receive(:valid?) { true }
-      allow(program).to receive(:[]).and_return(?+, nil)
+      allow(program).to receive(:instruction).with(0).and_return(?+, nil)
       allow(program).to receive(:size).and_return(1)
       allow(memory).to receive(:minimum_value).and_return(0)
       allow(memory).to receive(:maximum_value).and_return(10)
@@ -37,7 +37,7 @@ describe Brainfuck::Machine do
     describe "#fetch" do
       let(:instruction) { ?+ }
       it "fetches an instruction" do
-        allow(program).to receive(:[]).with(0).and_return(instruction)
+        allow(program).to receive(:instruction).with(0).and_return(instruction)
         expect(subject.send(:fetch)).to eq(instruction)
       end
     end

--- a/spec/program_spec.rb
+++ b/spec/program_spec.rb
@@ -120,20 +120,20 @@ describe Brainfuck::Program do
     end
   end
 
-  describe "#[]" do
-    it "has a [] method" do
-      expect(subject).to respond_to(:[]).with(1).argument
+  describe "#instruction" do
+    it "has a instruction method" do
+      expect(subject).to respond_to(:instruction).with(1).argument
     end
     it "returns an instruction" do
-      expect(subject[0]).to eq("+")
-      expect(subject[1]).to eq("-")
-      expect(subject[2]).to eq("+")
+      expect(subject.instruction(0)).to eq("+")
+      expect(subject.instruction(1)).to eq("-")
+      expect(subject.instruction(2)).to eq("+")
     end
     it "raises an exception if index too small" do
-      expect{ subject[-1] }.to raise_exception(ArgumentError)
+      expect{ subject.instruction(-1) }.to raise_exception(ArgumentError)
     end
     it "raises an exception if index too big" do
-      expect{ subject[instructions.length + 1] }.to raise_exception(ArgumentError)
+      expect{ subject.instruction(instructions.length + 1) }.to raise_exception(ArgumentError)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
 
   def mock_program_string(program, instructions)
     instructions.chars.each.with_index do |instruction, index|
-      allow(program).to receive(:[]).with(index).and_return(instruction)
+      allow(program).to receive(:instruction).with(index).and_return(instruction)
     end
   end
 


### PR DESCRIPTION
Previously instructions could be accessed directly from the array that backs them. This update changes all access to go through the #instruction method. This update paves the way for unifying the interface between `Program`, `Memory`, `Input`, and `Output` to use `#read`, and `write` methods taking zero one or (in the case of memory) two arguments.

These will serve as "hook" points for for debugging, instrumentation, and verbose logging.