### PR TITLE
Interface unification

### DIFF
--- a/lib/brainfuck/machine.rb
+++ b/lib/brainfuck/machine.rb
@@ -43,7 +43,7 @@ module Brainfuck
     end
 
     def fetch
-      program.instruction(instruction_pointer)
+      program.read(instruction_pointer)
     end
 
     def increment_instruction_pointer

--- a/lib/brainfuck/machine.rb
+++ b/lib/brainfuck/machine.rb
@@ -67,44 +67,31 @@ module Brainfuck
     def noop; end
 
     def increment_data_pointer
-      if (0...memory.size).include?(data_pointer + 1)
-        @data_pointer += 1
-      else
-        @data_pointer = 0
-      end
+      value = @data_pointer + 1
+      value = 0 unless (0...memory.size).include?(value)
+      @data_pointer = value
     end
 
     def decrement_data_pointer
-      if (0...data_pointer).include?(data_pointer - 1)
-        @data_pointer -= 1
-      else
-        @data_pointer = (memory.size - 1)
-      end
+      value = @data_pointer - 1
+      value = (memory.size - 1) unless (0...data_pointer).include?(value)
+      @data_pointer = value
     end
 
     def increment_data_at_data_pointer
-      if (memory.minimum_value...memory.maximum_value).include?(memory.read(data_pointer))
-        new_value = memory.read(data_pointer) + 1
-        memory.write(data_pointer,new_value)
-      else
-        memory.write(data_pointer, memory.minimum_value)
-      end
+      value = memory.read(data_pointer) + 1
+      value = memory.minimum_value unless (memory.minimum_value..memory.maximum_value).include?(value)
+      memory.write(data_pointer, value)
     end
 
     def decrement_data_at_data_pointer
-      if (memory.minimum_value.next...memory.maximum_value).include?(memory.read(data_pointer))
-        new_value = memory.read(data_pointer) - 1
-        memory.write(data_pointer, new_value)
-      else
-        memory.write(data_pointer, memory.maximum_value)
-      end
+      value = memory.read(data_pointer) - 1
+      value = memory.maximum_value unless (memory.minimum_value..memory.maximum_value).include?(value)
+      memory.write(data_pointer, value)
     end
 
     def read_byte_from_stdin_to_data_pointer_cell
-      value = nil
-      until (memory.minimum_value..memory.maximum_value).include?(value)
-        value = @input.read
-      end
+      value = @input.read until (memory.minimum_value..memory.maximum_value).include?(value)
       memory.write(data_pointer, value)
     end
 

--- a/lib/brainfuck/machine.rb
+++ b/lib/brainfuck/machine.rb
@@ -83,18 +83,20 @@ module Brainfuck
     end
 
     def increment_data_at_data_pointer
-      if (memory.minimum_value...memory.maximum_value).include?(memory[data_pointer])
-        memory[data_pointer] += 1
+      if (memory.minimum_value...memory.maximum_value).include?(memory.read(data_pointer))
+        new_value = memory.read(data_pointer) + 1
+        memory.write(data_pointer,new_value)
       else
-        memory[data_pointer] = memory.minimum_value
+        memory.write(data_pointer, memory.minimum_value)
       end
     end
 
     def decrement_data_at_data_pointer
-      if (memory.minimum_value.next...memory.maximum_value).include?(memory[data_pointer])
-        memory[data_pointer] -= 1
+      if (memory.minimum_value.next...memory.maximum_value).include?(memory.read(data_pointer))
+        new_value = memory.read(data_pointer) - 1
+        memory.write(data_pointer, new_value)
       else
-        memory[data_pointer] = memory.maximum_value
+        memory.write(data_pointer, memory.maximum_value)
       end
     end
 
@@ -103,15 +105,15 @@ module Brainfuck
       until (memory.minimum_value..memory.maximum_value).include?(value)
         value = @input.read
       end
-      memory[data_pointer] = value
+      memory.write(data_pointer, value)
     end
 
     def write_byte_from_data_pointer_cell_to_stdout
-      @output.write(memory[data_pointer])
+      @output.write(memory.read(data_pointer))
     end
 
     def jump_forward_on_zero_at_data_pointer
-      return unless memory[data_pointer].zero?
+      return unless memory.read(data_pointer).zero?
       jump_forward_markers_seen = 1
       until jump_forward_markers_seen.zero? do
         increment_instruction_pointer
@@ -123,7 +125,7 @@ module Brainfuck
     end
 
     def jump_backward_on_non_zero_at_data_pointer
-      return if memory[data_pointer].zero?
+      return if memory.read(data_pointer).zero?
       jump_backward_markers_seen = 1
       until jump_backward_markers_seen.zero? do
         decrement_instruction_pointer

--- a/lib/brainfuck/memory.rb
+++ b/lib/brainfuck/memory.rb
@@ -12,9 +12,9 @@ module Brainfuck
 
     def_delegator :@value_range, :min, :minimum_value
     def_delegator :@value_range, :max, :maximum_value
-    def_delegators :@cells, :size, :[]
+    def_delegator :@cells, :size
 
-    check_bounds :[], :[]=, proc: ->(i) { (0..size).include? i }
+    check_bounds :read, :write, proc: ->(i) { (0..size).include? i }
 
     def initialize(size: DEFAULT_SIZE, minimum: MIN_VALUE, maximum: MAX_VALUE, default: MIN_VALUE)
       size, min, max, default = [size, minimum, maximum, default].map(&:to_i)
@@ -25,7 +25,11 @@ module Brainfuck
       @cells = Array.new(size, default)
     end
 
-    def []=(index, value)
+    def read(index)
+      @cells.fetch(index)
+    end
+
+    def write(index, value)
       raise ArgumentError.new("Invalid value for cell") unless @value_range.include?(value)
       @cells[index] = value
     end

--- a/lib/brainfuck/program.rb
+++ b/lib/brainfuck/program.rb
@@ -12,7 +12,7 @@ module Brainfuck
 
     def_delegators :instructions, :size
 
-    check_bounds :instruction, proc: ->(i) { (0..size).include? i }
+    check_bounds :read, proc: ->(i) { (0..size).include? i }
 
     def self.from_file(filename)
       source = File.read(filename)
@@ -29,7 +29,7 @@ module Brainfuck
       @source = source.to_s
     end
 
-    def instruction(index)
+    def read(index)
       instructions.fetch(index)
     end
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -33,7 +33,7 @@ describe Brainfuck, integration: true do
     let(:program) { integration_source "math_to_seven.bf" }
     it "calculates the correct value and outputs a single byte" do
       expect(STDOUT).to receive(:write).with(?7).and_return(1)
-      expect{ subject }.to change{interpreter.memory[0]}.to(?7.ord)
+      expect{ subject }.to change{interpreter.memory.read(0)}.to(?7.ord)
     end
   end
 

--- a/spec/machine_spec.rb
+++ b/spec/machine_spec.rb
@@ -15,7 +15,7 @@ describe Brainfuck::Machine do
   describe "#run" do
     it "runs a valid program" do
       allow(program).to receive(:valid?) { true }
-      allow(program).to receive(:instruction).with(0).and_return(?+, nil)
+      allow(program).to receive(:read).with(0).and_return(?+, nil)
       allow(program).to receive(:size).and_return(1)
       allow(memory).to receive(:minimum_value).and_return(0)
       allow(memory).to receive(:maximum_value).and_return(10)
@@ -37,7 +37,7 @@ describe Brainfuck::Machine do
     describe "#fetch" do
       let(:instruction) { ?+ }
       it "fetches an instruction" do
-        allow(program).to receive(:instruction).with(0).and_return(instruction)
+        allow(program).to receive(:read).with(0).and_return(instruction)
         expect(subject.send(:fetch)).to eq(instruction)
       end
     end

--- a/spec/machine_spec.rb
+++ b/spec/machine_spec.rb
@@ -19,8 +19,8 @@ describe Brainfuck::Machine do
       allow(program).to receive(:size).and_return(1)
       allow(memory).to receive(:minimum_value).and_return(0)
       allow(memory).to receive(:maximum_value).and_return(10)
-      allow(memory).to receive(:[]).with(0).and_return(0)
-      allow(memory).to receive(:[]=).with(0, 1).and_return(1)
+      allow(memory).to receive(:read).with(0).and_return(0)
+      allow(memory).to receive(:write).with(0, 1).and_return(1)
       expect(subject.run).to eq(true)
     end
     context "with an invalid program" do
@@ -126,8 +126,8 @@ describe Brainfuck::Machine do
           machine.instance_variable_set(:@data_pointer, 0)
           allow(memory).to receive(:minimum_value).and_return(0)
           allow(memory).to receive(:maximum_value).and_return(10)
-          allow(memory).to receive(:[]).with(0).and_return(5)
-          expect(memory).to receive(:[]=).with(0, 6).and_return(6)
+          allow(memory).to receive(:read).with(0).and_return(5)
+          expect(memory).to receive(:write).with(0, 6).and_return(6)
           expect(subject).to eq(6)
         end
         context "when the value is at the maximimum" do
@@ -135,8 +135,8 @@ describe Brainfuck::Machine do
             machine.instance_variable_set(:@data_pointer, 0)
             allow(memory).to receive(:minimum_value).and_return(0)
             allow(memory).to receive(:maximum_value).and_return(10)
-            allow(memory).to receive(:[]).with(0).and_return(10)
-            expect(memory).to receive(:[]=).with(0, 0).and_return(0)
+            allow(memory).to receive(:read).with(0).and_return(10)
+            expect(memory).to receive(:write).with(0, 0).and_return(0)
             expect(subject).to eq(0)
           end
         end
@@ -148,16 +148,16 @@ describe Brainfuck::Machine do
           machine.instance_variable_set(:@data_pointer, 0)
           allow(memory).to receive(:minimum_value).and_return(0)
           allow(memory).to receive(:maximum_value).and_return(10)
-          allow(memory).to receive(:[]).with(0).and_return(5)
-          expect(memory).to receive(:[]=).with(0, 4).and_return(4)
+          allow(memory).to receive(:read).with(0).and_return(5)
+          expect(memory).to receive(:write).with(0, 4).and_return(4)
           expect(subject).to eq(4)
         end
         context "when the value is at the minimum" do
           it "wraps to the maximum" do
             allow(memory).to receive(:minimum_value).and_return(0)
             allow(memory).to receive(:maximum_value).and_return(10)
-            allow(memory).to receive(:[]).with(0).and_return(0)
-            expect(memory).to receive(:[]=).with(0, 10).and_return(10)
+            allow(memory).to receive(:read).with(0).and_return(0)
+            expect(memory).to receive(:write).with(0, 10).and_return(10)
             expect(subject).to eq(10)
           end
         end
@@ -166,7 +166,7 @@ describe Brainfuck::Machine do
       describe "#write_byte_from_data_pointer_cell_to_stdout '.'" do
         subject { machine.send(:dispatch, :write_byte_from_data_pointer_cell_to_stdout) }
         it "writes a byte" do
-          allow(memory).to receive(:[]).with(0).and_return(120)
+          allow(memory).to receive(:read).with(0).and_return(120)
           expect(output).to receive(:write).with(120).and_return(1)
           expect(subject).to eq(1)
         end
@@ -179,7 +179,7 @@ describe Brainfuck::Machine do
           allow(memory).to receive(:minimum_value).and_return(0)
           allow(memory).to receive(:maximum_value).and_return(255)
           allow(input).to receive(:read).and_return(120)
-          expect(memory).to receive(:[]=).with(0, 120).and_return(120)
+          expect(memory).to receive(:write).with(0, 120).and_return(120)
           expect(subject).to eq(120)
         end
         context "when the value read is not in the value range" do
@@ -188,7 +188,7 @@ describe Brainfuck::Machine do
             allow(memory).to receive(:minimum_value).and_return(10)
             allow(memory).to receive(:maximum_value).and_return(100)
             allow(input).to receive(:read).and_return( 1, 200, 50)
-            expect(memory).to receive(:[]=).with(0, 50.ord).and_return(50)
+            expect(memory).to receive(:write).with(0, 50.ord).and_return(50)
             expect(subject).to eq(50)
           end
         end
@@ -199,14 +199,14 @@ describe Brainfuck::Machine do
         it "jumps forward to the next ']' instruction" do
           machine.instance_variable_set(:@data_pointer, 0)
           machine.instance_variable_set(:@instruction_pointer, 0)
-          allow(memory).to receive(:[]).with(0).and_return(0)
+          allow(memory).to receive(:read).with(0).and_return(0)
           mock_program_string(program, "[+]")
           expect{ subject }.to change(machine, :instruction_pointer).by(2)
         end
         it "jumps forward to the next *matching* ']' instruction" do
           machine.instance_variable_set(:@data_pointer, 0)
           machine.instance_variable_set(:@instruction_pointer, 0)
-          allow(memory).to receive(:[]).with(0).and_return(0)
+          allow(memory).to receive(:read).with(0).and_return(0)
           mock_program_string(program, "[+[[++]--][>><<]--++]>>++")
           expect{ subject }.to change(machine, :instruction_pointer).by(20)
         end
@@ -214,7 +214,7 @@ describe Brainfuck::Machine do
           it "doesn't jump" do
             machine.instance_variable_set(:@data_pointer, 0)
             machine.instance_variable_set(:@instruction_pointer, 0)
-            allow(memory).to receive(:[]).with(0).and_return(1)
+            allow(memory).to receive(:read).with(0).and_return(1)
             expect{ subject }.not_to change(machine, :instruction_pointer)
           end
         end
@@ -225,14 +225,14 @@ describe Brainfuck::Machine do
         it "jumps backward to the last '['" do
           machine.instance_variable_set(:@data_pointer, 0)
           machine.instance_variable_set(:@instruction_pointer, 2)
-          allow(memory).to receive(:[]).with(0).and_return(1)
+          allow(memory).to receive(:read).with(0).and_return(1)
           mock_program_string(program, "[+]")
           expect{ subject }.to change(machine, :instruction_pointer).by(-2)
         end
         it "jumps backward to the last *matching* '[' instruction" do
           machine.instance_variable_set(:@data_pointer, 1)
           machine.instance_variable_set(:@instruction_pointer, 20)
-          allow(memory).to receive(:[]).with(1).and_return(1)
+          allow(memory).to receive(:read).with(1).and_return(1)
           mock_program_string(program, "[+[[++]--][>><<]--++]>>++")
           expect{ subject }.to change(machine, :instruction_pointer).by(-20)
         end
@@ -240,7 +240,7 @@ describe Brainfuck::Machine do
           it "doesn't jump" do
             machine.instance_variable_set(:@data_pointer, 0)
             machine.instance_variable_set(:@instruction_pointer, 1)
-            allow(memory).to receive(:[]).with(0).and_return(0)
+            allow(memory).to receive(:read).with(0).and_return(0)
             expect{ subject }.not_to change(machine, :instruction_pointer)
           end
         end

--- a/spec/memory_spec.rb
+++ b/spec/memory_spec.rb
@@ -75,45 +75,45 @@ describe Brainfuck::Memory do
     end
   end
 
-  describe "#[]" do
-    it "responds to []" do
-      expect(subject).to respond_to(:[])
+  describe "#read" do
+    it "responds to #read" do
+      expect(subject).to respond_to(:read).with(1).argument
     end
     context "with index in range" do
       let(:index) { 1 }
       it "returns the value" do
-        expect(subject[index]).to eq(default)
+        expect(subject.read(index)).to eq(default)
       end
     end
     context "with index out of range" do
       let(:small_index) { -1 }
       let(:big_index) { size.next }
       it "raises an exception" do
-        expect{ subject[big_index] }.to raise_exception(ArgumentError)
-        expect{ subject[small_index] }.to raise_exception(ArgumentError)
+        expect{ subject.read(big_index) }.to raise_exception(ArgumentError)
+        expect{ subject.read(small_index) }.to raise_exception(ArgumentError)
       end
     end
   end
 
-  describe "#[]=" do
-    it "responds to []=" do
-      expect(subject).to respond_to(:[]=)
+  describe "#write" do
+    it "responds to #write" do
+      expect(subject).to respond_to(:write).with(2).arguments
     end
     context "with index in range" do
       let(:index) { 0 }
       context "with value in range" do
         it "sets the value" do
-          expect(subject[index] = default).to eq(default)
-          expect(subject[index] = minimum).to eq(minimum)
-          expect(subject[index] = maximum).to eq(maximum)
+          expect(subject.write(index, default)).to eq(default)
+          expect(subject.write(index, minimum)).to eq(minimum)
+          expect(subject.write(index, maximum)).to eq(maximum)
         end
       end
       context "with value out of range" do
         let(:small_value) { minimum - 1 }
         let(:big_value) { maximum.next }
         it "sets the value" do
-            expect{ subject[index] = small_value }.to raise_exception{ArgumentError}
-            expect{ subject[index] = big_value }.to raise_exception{ArgumentError}
+            expect{ subject.write(index, small_value) }.to raise_exception{ArgumentError}
+            expect{ subject.write(index, big_value) }.to raise_exception{ArgumentError}
         end
       end
     end
@@ -121,8 +121,8 @@ describe Brainfuck::Memory do
       let(:small_index) { -1 }
       let(:big_index) { size.next }
       it "raises an exception" do
-        expect{ subject[big_index] = default }.to raise_exception(ArgumentError)
-        expect{ subject[small_index] = default }.to raise_exception(ArgumentError)
+        expect{ subject.write(big_index, default) }.to raise_exception(ArgumentError)
+        expect{ subject.write(small_index, default) }.to raise_exception(ArgumentError)
       end
     end
   end

--- a/spec/program_spec.rb
+++ b/spec/program_spec.rb
@@ -120,20 +120,20 @@ describe Brainfuck::Program do
     end
   end
 
-  describe "#instruction" do
-    it "has a instruction method" do
-      expect(subject).to respond_to(:instruction).with(1).argument
+  describe "#read" do
+    it "has a read method" do
+      expect(subject).to respond_to(:read).with(1).argument
     end
-    it "returns an instruction" do
-      expect(subject.instruction(0)).to eq("+")
-      expect(subject.instruction(1)).to eq("-")
-      expect(subject.instruction(2)).to eq("+")
+    it "returns an read" do
+      expect(subject.read(0)).to eq("+")
+      expect(subject.read(1)).to eq("-")
+      expect(subject.read(2)).to eq("+")
     end
     it "raises an exception if index too small" do
-      expect{ subject.instruction(-1) }.to raise_exception(ArgumentError)
+      expect{ subject.read(-1) }.to raise_exception(ArgumentError)
     end
     it "raises an exception if index too big" do
-      expect{ subject.instruction(instructions.length + 1) }.to raise_exception(ArgumentError)
+      expect{ subject.read(instructions.length + 1) }.to raise_exception(ArgumentError)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,6 @@ end
 
 def mock_program_string(program, instructions)
   instructions.chars.each.with_index do |instruction, index|
-    allow(program).to receive(:instruction).with(index).and_return(instruction)
+    allow(program).to receive(:read).with(index).and_return(instruction)
   end
 end


### PR DESCRIPTION
Some thoughts: it seems like there are four methods for the interface that we need to think about:

  1. `read(index)` that reads a single value from an addressable store (e.g. program)
  2. `read()` that reads a value from a non-addressable store (e.g. stdin)
  3. `write(index value)` that writes a value to an addressable store (e.g. memory)
  4. `write(value)` that writes a value to a non-addressable store (e.g. stdout)

I've made a branch that to address the concerns in #8 so far as the read/write methods are concerned. I think it may be a good idea to expand the bounds_checking module to have some standard behaviours.

I think the best solution for behaviours like clamping values might be to just have custom methods in sub-classes. There may be a way to make a nice interface for that kind of thing by expanding the bounds checking module, but that's another PR.